### PR TITLE
Add extensions methods for setting common Request/Response properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,45 @@ Easy mocking for ASP.NET Core HttpContext.
 
 HttpContextMoq is an implementation of `AspNetCore.Http.HttpContext` that stores a Mock<HttpContext> instance and works as a proxy for the real Mock.
 
-## Getting Started
+## Instalation
+
+## Usage
+
+Basic GET request:
+```csharp
+
+var context = new HttpContextMock()
+    .SetupUrl("http://localhost:8000/path")
+    .SetupRequestMethod("GET");
+```
+
+POST request (with body):
+
+```csharp
+var data = Encoding.UTF8.GetBytes("{\"Foo\":\"Bar\"");
+
+var context = new HttpContextMock()
+    .SetupUrl("http://localhost:8000/path")
+    .SetupRequestMethod("POST")
+    .SetupRequestContentType("application/json")
+    .SetupRequestBody(new MemoryStream(data))
+    .SetupRequestContentLength(data.Length);
+```
+
+Request/Response pair, usefull for testing Action Filters:
+
+```csharp
+var data = Encoding.UTF8.GetBytes("{\"Foo\":\"Bar\"");
+
+var context = new HttpContextMock()
+    .SetupUrl("http://localhost:8000/path")
+    .SetupRequestMethod("GET")
+    .SetupResponseContentType("application/json")
+    .SetupResponseBody(new MemoryStream(data))
+    .SetupResponseContentLength(data.Length);
+```
+
+## Development
 
 Open the solution `src\HttpContextMoq.sln` on Visual Studio.
 

--- a/src/HttpContextMoq/Extensions/ContextExtensions.cs
+++ b/src/HttpContextMoq/Extensions/ContextExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
@@ -42,9 +43,30 @@ namespace HttpContextMoq.Extensions
             return httpContextMock;
         }
 
+        public static HttpContextMock SetupRequestMethod(this HttpContextMock httpContextMock, string method)
+        {
+            httpContextMock.RequestMock.Mock.Setup(x => x.Method).Returns(method);
+
+            return httpContextMock;
+        }
+
         public static HttpContextMock SetupRequestBody(this HttpContextMock httpContextMock, Stream stream)
         {
             httpContextMock.RequestMock.Mock.Setup(x => x.Body).Returns(stream);
+
+            return httpContextMock;
+        }
+
+        public static HttpContextMock SetupRequestContentType(this HttpContextMock httpContextMock, string contentType)
+        {
+            httpContextMock.RequestMock.Mock.Setup(x => x.ContentType).Returns(contentType);
+
+            return httpContextMock;
+        }
+
+        public static HttpContextMock SetupRequestContentLength(this HttpContextMock httpContextMock, long? contentLength)
+        {
+            httpContextMock.RequestMock.Mock.Setup(x => x.ContentLength).Returns(contentLength);
 
             return httpContextMock;
         }
@@ -59,6 +81,44 @@ namespace HttpContextMoq.Extensions
         public static HttpContextMock SetupRequestCookies(this HttpContextMock httpContextMock, IDictionary<string, string> cookies)
         {
             httpContextMock.RequestMock.Cookies = new RequestCookieCollectionFake(cookies);
+
+            return httpContextMock;
+        }
+
+
+        public static HttpContextMock SetupResponseStatusCode(this HttpContextMock httpContextMock, HttpStatusCode statusCode) => SetupResponseStatusCode(httpContextMock, (int) statusCode);
+
+        public static HttpContextMock SetupResponseStatusCode(this HttpContextMock httpContextMock, int statusCode)
+        {
+            httpContextMock.ResponseMock.Mock.Setup(x => x.StatusCode).Returns(statusCode);
+
+            return httpContextMock;
+        }
+
+        public static HttpContextMock SetupResponseBody(this HttpContextMock httpContextMock, Stream stream)
+        {
+            httpContextMock.ResponseMock.Mock.Setup(x => x.Body).Returns(stream);
+
+            return httpContextMock;
+        }
+
+        public static HttpContextMock SetupResponseContentType(this HttpContextMock httpContextMock, string contentType)
+        {
+            httpContextMock.ResponseMock.Mock.Setup(x => x.ContentType).Returns(contentType);
+
+            return httpContextMock;
+        }
+
+        public static HttpContextMock SetupResponseHeaders(this HttpContextMock httpContextMock, IDictionary<string, StringValues> headers)
+        {
+            httpContextMock.ResponseMock.SetHeaders(new HeaderDictionaryFake(headers));
+
+            return httpContextMock;
+        }
+
+        public static HttpContextMock SetupResponseContentLength(this HttpContextMock httpContextMock, long? contentLength)
+        {
+            httpContextMock.ResponseMock.Mock.Setup(x => x.ContentLength).Returns(contentLength);
 
             return httpContextMock;
         }

--- a/src/HttpContextMoq/HttpContextMoq.csproj
+++ b/src/HttpContextMoq/HttpContextMoq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>HttpContextMoq</AssemblyName>
     <RootNamespace>HttpContextMoq</RootNamespace>
     <AssetTargetFallback>
@@ -18,6 +18,7 @@
     <IsPackable>True</IsPackable>
     <PackageId>HttpContextMoq</PackageId>
     <Title>HttpContextMoq: Easy mocking for ASP.NET Core HttpContext</Title>
+    <Description>HttpContextMoq is an implementation of AspNetCore.Http.HttpContext that stores a Mock instance and works as a proxy for the real Mock.</Description>
     <Authors>Tiago Araújo</Authors>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/tiagodaraujo/httpcontextmoq</PackageProjectUrl>
@@ -27,7 +28,7 @@
     <Version>1.2.2</Version>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/HttpContextMoq/HttpResponseMock.cs
+++ b/src/HttpContextMoq/HttpResponseMock.cs
@@ -88,6 +88,12 @@ namespace HttpContextMoq
             set => this.Mock.Object.StatusCode = value;
         }
 
+        internal void SetHeaders(IHeaderDictionary headers)
+        {
+            this._headers = headers;
+            this.Mocks.Add(headers);
+        }
+
         public override void OnCompleted(Func<object, Task> callback, object state) => this.Mock.Object.OnCompleted(callback, state);
 
         public override void OnStarting(Func<object, Task> callback, object state) => this.Mock.Object.OnStarting(callback, state);

--- a/tests/HttpContextMoq.Tests/Extensions/ContextExtensionsTests.cs
+++ b/tests/HttpContextMoq.Tests/Extensions/ContextExtensionsTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -175,6 +177,151 @@ namespace HttpContextMoq.Extensions.Tests
             context.Request.Cookies.ContainsKey("notexist").Should().BeFalse();
             context.Request.Cookies.TryGetValue("notexist", out var valueNotExist).Should().BeFalse();
             valueNotExist.Should().BeNull();
+        }
+
+        [Fact]
+        public void SetupRequestMethod_WhenValue_ShouldSetMethod()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+            var headers = new Dictionary<string, StringValues>();
+
+            // Act
+            context.SetupRequestMethod(HttpMethods.Post);
+
+            // Assert
+            context.Request.Method.Should().Be(HttpMethods.Post);
+        }
+
+        [Fact]
+        public void SetupRequestContentLength_WhenValue_ShouldSetContentLength()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+
+            // Act
+            context.SetupRequestContentLength(123);
+
+            // Assert
+            context.Request.ContentLength.Should().Be(123);
+        }
+
+        [Fact]
+        public void SetupRequestContentType_WhenValue_ShouldSetContentType()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+
+            // Act
+            context.SetupRequestContentType("application/json");
+
+            // Assert
+            context.Request.ContentType.Should().Be("application/json");
+        }
+
+        [Fact]
+        public void SetupResponseHeaders_WhenEmpty_ShouldNoHeaders()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+            var headers = new Dictionary<string, StringValues>();
+
+            // Act
+            context.SetupResponseHeaders(headers);
+
+            // Assert
+            context.Response.Headers.Count.Should().Be(0);
+            context.Response.Headers.Should().HaveCount(0);
+        }
+
+        [Fact]
+        public void SetupResponseHeaders_WhenHaveHeaders_ShouldHaveHeaders()
+        {
+            // Arrange
+            const string header1 = "header1", header2 = "header2", value1 = "value1", value2 = "value2";
+            var context = new HttpContextMock();
+            var headers = new Dictionary<string, StringValues> {
+                { header1, value1 },
+                { header2, value2 }
+            };
+
+            // Act
+            context.SetupResponseHeaders(headers);
+
+            // Assert
+            context.Response.Headers.Count.Should().Be(headers.Count);
+            context.Response.Headers.Should().HaveCount(headers.Count);
+            context.Response.Headers.Should().BeEquivalentTo(headers);
+            foreach (var item in headers)
+            {
+                context.Response.Headers[item.Key].Should().BeEquivalentTo(item.Value);
+                context.Response.Headers.ContainsKey(item.Key).Should().BeTrue();
+                context.Response.Headers.Contains(new KeyValuePair<string, StringValues>(item.Key, item.Value)).Should().BeTrue();
+                context.Response.Headers.TryGetValue(item.Key, out var value).Should().BeTrue();
+                value.Should().BeEquivalentTo(item.Value);
+            }
+
+            context.Response.Headers["notexist"].Should().BeEquivalentTo(StringValues.Empty);
+            context.Response.Headers.ContainsKey("notexist").Should().BeFalse();
+            context.Response.Headers.Contains(new KeyValuePair<string, StringValues>("notexist", "notexist")).Should().BeFalse();
+            context.Response.Headers.TryGetValue("notexist", out var valueNotExist).Should().BeFalse();
+            valueNotExist.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void SetupResponseContentLength_WhenValue_ShouldSetContentLength()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+
+            // Act
+            context.SetupResponseContentLength(123);
+
+            // Assert
+            context.Response.ContentLength.Should().Be(123);
+        }
+
+        [Fact]
+        public void SetupResponseContentType_WhenValue_ShouldSetContentType()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+
+            // Act
+            context.SetupResponseContentType("application/json");
+
+            // Assert
+            context.Response.ContentType.Should().Be("application/json");
+        }
+
+        [Fact]
+        public void SetupResponseStatusCode_WhenValue_ShouldSetStatusCode()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+
+            // Act
+            context.SetupResponseStatusCode(System.Net.HttpStatusCode.PartialContent);
+
+            // Assert
+            context.Response.StatusCode.Should().Be(206);
+        }
+
+        [Fact]
+        public void SetupResponseBody_WhenValue_ShouldSetBody()
+        {
+            // Arrange
+            var context = new HttpContextMock();
+            var body = new MemoryStream(new byte[] { 0x1, 0x2, 0x3 });
+
+            // Act
+            context.SetupResponseBody(body);
+
+            // Assert
+            var data = new MemoryStream();
+            context.Response.Body.CopyTo(data);
+
+            data.ToArray().Should().BeEquivalentTo(0x1, 0x2, 0x3);
         }
 
         [Fact]


### PR DESCRIPTION
I added several more extension methods, as they make using of this library way easier. The changes allow for settings commonly used properties of HTTP Request/Response like Method, Content Type, Body, Content Length.

I also updated the Readme as it lacked simple how-to example.

Example 
```csharp
var context = new HttpContextMock()
    .SetupUrl("http://localhost:8000/path")
    .SetupRequestMethod("POST")
    .SetupRequestContentType("application/json")
    .SetupRequestBody(new MemoryStream(data))
    .SetupRequestContentLength(data.Length)
    .SetupResponseContentType("application/json")
    .SetupResponseBody(new MemoryStream(data))
    .SetupResponseContentLength(data.Length);
```