### PR TITLE
Overrides HttpResponse.BodyWriter

### DIFF
--- a/src/HttpContextMoq/Extensions/ContextExtensions.cs
+++ b/src/HttpContextMoq/Extensions/ContextExtensions.cs
@@ -55,6 +55,10 @@ public static class ContextExtensions
     {
         httpContextMock.RequestMock.Mock.Setup(x => x.Body).Returns(stream);
 
+#if NET9_0_OR_GREATER
+        httpContextMock.RequestMock.Mock.Setup(s => s.BodyReader).Returns(System.IO.Pipelines.PipeReader.Create(stream));
+#endif
+
         return httpContextMock;
     }
 
@@ -101,7 +105,7 @@ public static class ContextExtensions
         httpContextMock.ResponseMock.Mock.Setup(x => x.Body).Returns(stream);
 
 #if NET9_0_OR_GREATER
-        httpContextMock.ResponseMock.Mock.Setup(s => s.BodyWriter).Returns(System.IO.Pipelines.PipeWriter.Create(stream));
+        httpContextMock.ResponseMock.Mock.Setup(s => s.BodyWriter).Returns(System.IO.Pipelines.PipeWriter.Create(stream, writerOptions: new System.IO.Pipelines.StreamPipeWriterOptions(leaveOpen: true)));
 #endif
         return httpContextMock;
     }

--- a/src/HttpContextMoq/Extensions/ContextExtensions.cs
+++ b/src/HttpContextMoq/Extensions/ContextExtensions.cs
@@ -100,6 +100,9 @@ public static class ContextExtensions
     {
         httpContextMock.ResponseMock.Mock.Setup(x => x.Body).Returns(stream);
 
+#if NET9_0_OR_GREATER
+        httpContextMock.ResponseMock.Mock.Setup(s => s.BodyWriter).Returns(System.IO.Pipelines.PipeWriter.Create(stream));
+#endif
         return httpContextMock;
     }
 

--- a/src/HttpContextMoq/HttpContextMoq.csproj
+++ b/src/HttpContextMoq/HttpContextMoq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 		<AssemblyName>HttpContextMoq</AssemblyName>
 		<RootNamespace>HttpContextMoq</RootNamespace>
 		<AssetTargetFallback>

--- a/src/HttpContextMoq/HttpResponseMock.cs
+++ b/src/HttpContextMoq/HttpResponseMock.cs
@@ -88,6 +88,10 @@ namespace HttpContextMoq
             set => this.Mock.Object.StatusCode = value;
         }
 
+#if NET9_0_OR_GREATER
+        public override System.IO.Pipelines.PipeWriter BodyWriter => this.Mock.Object.BodyWriter;
+#endif
+
         internal void SetHeaders(IHeaderDictionary headers)
         {
             this._headers = headers;

--- a/tests/HttpContextMoq.Tests/HttpContextMoq.Tests.csproj
+++ b/tests/HttpContextMoq.Tests/HttpContextMoq.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<AssetTargetFallback>
 			$(AssetTargetFallback);netstandard2.0;netstandard2.1
 		</AssetTargetFallback>

--- a/tests/HttpContextMoq.Tests/HttpResponseMockTests.cs
+++ b/tests/HttpContextMoq.Tests/HttpResponseMockTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipelines;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -80,6 +81,11 @@ namespace HttpContextMoq.Tests
                     t => t.StatusCode,
                     t => t.StatusCode = Fakes.Int
                 ),
+#if NET9_0_OR_GREATER
+                new PropertyGetUnitTest<HttpResponseMock, HttpResponse, PipeWriter>(
+                    t => t.BodyWriter
+                ),
+#endif
                 //Methods
                 new MethodInvokeUnitTest<HttpResponseMock, HttpResponse>(
                     t => t.OnCompleted(It.IsAny<Func<Task>>())

--- a/tests/HttpContextMoq.Tests/HttpResponseMockTests.cs
+++ b/tests/HttpContextMoq.Tests/HttpResponseMockTests.cs
@@ -81,11 +81,9 @@ namespace HttpContextMoq.Tests
                     t => t.StatusCode,
                     t => t.StatusCode = Fakes.Int
                 ),
-#if NET9_0_OR_GREATER
                 new PropertyGetUnitTest<HttpResponseMock, HttpResponse, PipeWriter>(
                     t => t.BodyWriter
                 ),
-#endif
                 //Methods
                 new MethodInvokeUnitTest<HttpResponseMock, HttpResponse>(
                     t => t.OnCompleted(It.IsAny<Func<Task>>())


### PR DESCRIPTION
Resolves https://github.com/tiagodaraujo/HttpContextMoq/issues/11

Adds net9.0 to target frameworks.
Overrides HttpResponse.BodyWriter only for dotnet9.0 or newer.
Setup Response.BodyWriter in SetupRequestBody extension method.